### PR TITLE
Workers are separate

### DIFF
--- a/loadtest.py
+++ b/loadtest.py
@@ -5,7 +5,7 @@ from fxa.__main__ import DEFAULT_CLIENT_ID
 from fxa.core import Client
 from fxa.tests.utils import TestEmailAccount
 from fxa.tools.bearer import get_bearer_token
-from molotov import global_setup, global_teardown, setup, scenario
+from molotov import teardown_session, setup, scenario
 
 
 # Read configuration from env
@@ -19,7 +19,7 @@ COLLECTIONS = BUCKET + "/collections"
 STATUS_URL = "/v1/"
 VERSION_URL = "/v1/__version__"
 
-_FXA = {}
+_FXA_BY_WORKER_ID = {}
 
 async def json_or_error(r):
     if r.content_type != 'application/json':
@@ -29,8 +29,8 @@ async def json_or_error(r):
     return await r.json()
 
 
-@global_setup()
-def create_account_and_token(args):
+@setup()
+async def create_account_and_token(worker_id, args):
     acct = TestEmailAccount()
     passwd = str(uuid.uuid4())
     client = Client("https://api.accounts.firefox.com")
@@ -44,7 +44,8 @@ def create_account_and_token(args):
         raise RuntimeError("verification email did not arrive")
 
     session.verify_email_code(m["headers"]["x-verify-code"])
-    _FXA['token']= get_bearer_token(
+    fxa = {}
+    fxa['token']= get_bearer_token(
         acct.email,
         passwd,
         account_server_url="https://api.accounts.firefox.com/v1",
@@ -52,24 +53,23 @@ def create_account_and_token(args):
         scopes=['sync:addon_storage'],
         client_id=DEFAULT_CLIENT_ID
     )
-    _FXA['acct'] = acct
-    _FXA['passwd'] = passwd
-    _FXA['client'] = client
+    fxa['acct'] = acct
+    fxa['passwd'] = passwd
+    fxa['client'] = client
+    _FXA_BY_WORKER_ID[worker_id] = fxa
+
+    headers = {"Authorization": "Bearer %s" % fxa['token'], "Content-type": "application/json;charset=utf8"}
+    return {'headers': headers}
 
 
-@global_teardown()
-def cleanup_account():
-    acct = _FXA['acct']
-    client = _FXA['client']
-    passwd = _FXA['passwd']
+@teardown_session()
+async def cleanup_account(worker_id, _session):
+    fxa = _FXA_BY_WORKER_ID[worker_id]
+    acct = fxa['acct']
+    client = fxa['client']
+    passwd = fxa['passwd']
     acct.clear()
     client.destroy_account(acct.email, passwd)
-
-
-@setup()
-async def init_test(worker_id, args):
-    headers = {"Authorization": "Bearer %s" % _FXA['token'], "Content-type": "application/json;charset=utf8"}
-    return {'headers': headers}
 
 
 @scenario(75)

--- a/loadtest.py
+++ b/loadtest.py
@@ -13,7 +13,8 @@ SERVER_URL = os.getenv(
     'KINTO_WE_SERVER',
     "https://webextensions-settings.stage.mozaws.net").rstrip('/')
 
-COLLECTIONS = "/v1/buckets/default/collections"
+BUCKET = "/v1/buckets/default"
+COLLECTIONS = BUCKET + "/collections"
 
 STATUS_URL = "/v1/"
 VERSION_URL = "/v1/__version__"
@@ -90,3 +91,11 @@ async def create_records(session):
     # headers = {"Authorization": "Bearer %s" % _FXA['token'], "Content-type": "application/json;charset=utf8"}
     async with session.post(SERVER_URL + COLLECTIONS + '/qa_collection/records', data=payload) as resp:
         assert resp.status == 201
+
+
+@scenario(1)
+async def wipe_server(session):
+    async with session.delete(SERVER_URL + BUCKET) as resp:
+        if resp.status != 200:
+            text = await resp.text()
+            raise ValueError("deleting failed: {} {}".format(resp.status, text))


### PR DESCRIPTION
In general, requests by the same user can block one another, which
shows failure at very little load compared to what we actually see in
production, and in particular without causing much in the way of
server load. Therefore, rather than create one user and share it for
all the requests, create one per worker thread. This means we don't
explore the case of a single user hammering the server, but in
practice I expect most users to make only a handful of requests at a
time so as a measurement of scalability it may not be helpful.